### PR TITLE
Remove space in sed command for linux/macos compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build_image: init
 image: build_image
 	@echo "building scheduler docker image"
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
-	@sed -i '.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
+	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	@coreSHA=$$(go list -m "github.com/cloudera/yunikorn-core" | cut -d "-" -f4) ; \
 	siSHA=$$(go list -m "github.com/cloudera/yunikorn-scheduler-interface" | cut -d "-" -f5) ; \
 	shimSHA=$$(git rev-parse --short=12 HEAD) ; \


### PR DESCRIPTION
There was a space before the -i option which works on MACOSX buit causes the linux build to fail.
Remove the space.

Closes #11