### PR TITLE
expose scheduler events to K8s event system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ image: build_image
 run: build
 	@echo "running scheduler locally"
 	@cp ${LOCAL_CONF}/${CONF_FILE} ${RELEASE_BIN_DIR}
-	cd ${RELEASE_BIN_DIR} && ./${BINARY} -kubeConfig=$(HOME)/.kube/config -interval=1 \
+	cd ${RELEASE_BIN_DIR} && ./${BINARY} -kubeConfig=$(HOME)/.kube/config -interval=1s \
 	-clusterId=mycluster -clusterVersion=${VERSION} -name=yunikorn -policyGroup=queues \
 	-logEncoding=console -logLevel=-1
 

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -177,6 +177,10 @@ func (ctx *Context) addNode(obj interface{}) {
 
 	// add node to internal cache
 	ctx.nodes.addNode(node)
+
+	// post the event
+	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "Accepted",
+		"node is accepted by the scheduler")
 }
 
 func (ctx *Context) updateNode(oldObj, newObj interface{}) {
@@ -225,6 +229,10 @@ func (ctx *Context) deleteNode(obj interface{}) {
 
 	// delete node from primary cache
 	ctx.nodes.deleteNode(node)
+
+	// post the event
+	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "Deleted",
+		"node is deleted from the scheduler")
 }
 
 // add a pod to the context

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -40,8 +40,10 @@ func initContextForTest() *Context {
 		SchedulerName:  fakeClusterSchedulerName,
 		Interval:       fakeClusterSchedulingInterval,
 		KubeConfig:     "",
+		TestMode:       true,
 	}
 
+	conf.Set(&configs)
 	client := test.NewKubeClientMock()
 
 	context := NewContextInternal(nil, &configs, client, true)

--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 Cloudera, Inc.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"github.com/cloudera/yunikorn-k8shim/pkg/client"
+	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sync"
+)
+
+var eventRecorder record.EventRecorder = record.NewFakeRecorder(1024)
+var once sync.Once
+
+func GetRecorder() record.EventRecorder {
+	once.Do(func() {
+		// note, the initiation of the event recorder requires on a workable Kubernetes client,
+		// in test mode we should skip this and just use a fake recorder instead.
+		configs := conf.GetSchedulerConf()
+		if !configs.TestMode {
+			k8sClient := client.NewKubeClient(configs.KubeConfig)
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartRecordingToSink(&v1.EventSinkImpl{
+				Interface: k8sClient.GetClientSet().CoreV1().Events("")})
+			eventRecorder = eventBroadcaster.NewRecorder(scheme.Scheme,
+				corev1.EventSource{Component: configs.SchedulerName})
+		}
+	})
+
+	return eventRecorder
+}

--- a/pkg/common/events/recorder_test.go
+++ b/pkg/common/events/recorder_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 Cloudera, Inc.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
+	"gotest.tools/assert"
+	"reflect"
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	// simply test the get won't fail
+	// which means the get function honors the testMode and
+	// skips initiating a real event recorder
+	conf.Set(&conf.SchedulerConf{TestMode: true})
+	recorder := GetRecorder()
+	assert.Equal(t, reflect.TypeOf(recorder).String(), "*record.FakeRecorder")
+}

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -30,6 +30,7 @@ const (
 	DefaultLoggingLevel = 0
 	DefaultLogEncoding = "console"
 	DefaultVolumeBindTimeout = 10 * time.Second
+	DefaultSchedulingInterval = time.Second
 )
 
 var configuration *SchedulerConf
@@ -39,20 +40,26 @@ type SchedulerConf struct {
 	ClusterVersion    string        `json:"clusterVersion"`
 	SchedulerName     string        `json:"schedulerName"`
 	PolicyGroup       string        `json:"policyGroup"`
-	Interval          int           `json:"schedulingIntervalSecond"`
+	Interval          time.Duration `json:"schedulingIntervalSecond"`
 	KubeConfig        string        `json:"absoluteKubeConfigFilePath"`
 	LoggingLevel      int           `json:"loggingLevel"`
 	LogEncoding       string        `json:"logEncoding"`
 	LogFile           string        `json:"logFilePath"`
 	VolumeBindTimeout time.Duration `json:"volumeBindTimeout"`
+	TestMode          bool          `json:"testMode"`
 }
 
 func GetSchedulerConf() *SchedulerConf {
 	return configuration
 }
 
+// unit tests may need to override configuration
+func Set(conf *SchedulerConf) {
+	configuration = conf
+}
+
 func (conf *SchedulerConf) GetSchedulingInterval() time.Duration {
-	return time.Duration(conf.Interval) * time.Second
+	return conf.Interval
 }
 
 func (conf *SchedulerConf) GetKubeConfigPath() string {
@@ -63,7 +70,7 @@ func init() {
 	// scheduler options
 	kubeConfig := flag.String("kubeConfig", "",
 		"absolute path to the kubeconfig file")
-	schedulingInterval := flag.Int("interval", 1,
+	schedulingInterval := flag.Duration("interval", DefaultSchedulingInterval,
 		"scheduling interval in seconds")
 	clusterId := flag.String("clusterId", DefaultClusterId,
 		"cluster id")

--- a/pkg/plugin/predicates/predicator_test.go
+++ b/pkg/plugin/predicates/predicator_test.go
@@ -18,6 +18,7 @@ package predicates
 
 import (
 	"fmt"
+	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
 	"gotest.tools/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,6 +42,7 @@ var (
 )
 
 func TestPodFitsHost(t *testing.T) {
+	conf.Set(&conf.SchedulerConf{TestMode: true})
 	predictor := newPredictorInternal(&factory.PluginFactoryArgs{}, schedulerapi.Policy{
 		Predicates: []schedulerapi.PredicatePolicy{
 			{Name: predicates.HostNamePred},

--- a/pkg/plugin/predicates/predictor.go
+++ b/pkg/plugin/predicates/predictor.go
@@ -18,6 +18,7 @@ package predicates
 
 import (
 	"fmt"
+	"github.com/cloudera/yunikorn-k8shim/pkg/common/events"
 	"github.com/cloudera/yunikorn-k8shim/pkg/log"
 	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
@@ -270,6 +271,8 @@ func (p *Predictor) Predicates(pod *v1.Pod, meta predicates.PredicateMetadata, n
 					zap.String("key", predicateKey),
 					zap.Bool("fit", fit),
 					zap.Any("reasons", reasons))
+				events.GetRecorder().Eventf(pod, v1.EventTypeWarning,
+					"FailedScheduling", err.Error())
 				return err
 			}
 
@@ -278,6 +281,8 @@ func (p *Predictor) Predicates(pod *v1.Pod, meta predicates.PredicateMetadata, n
 					zap.String("key", predicateKey),
 					zap.Bool("fit", fit),
 					zap.Any("reasons", reasons))
+				events.GetRecorder().Eventf(pod, v1.EventTypeWarning,
+					"FailedScheduling", "%v", reasons)
 				return fmt.Errorf("predicate %s cannot be satisified, reason %v", predicateKey, reasons)
 			}
 		}

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -59,8 +59,10 @@ func (fc *MockScheduler) init(queues string) {
 		SchedulerName:  fakeClusterSchedulerName,
 		Interval:       fakeClusterSchedulingInterval,
 		KubeConfig:     "",
+		TestMode:       true,
 	}
 
+	conf.Set(&configs)
 	fc.conf = queues
 	fc.stopChan = make(chan struct{})
 	// default functions for bind and delete, this can be override if necessary


### PR DESCRIPTION
This patch contains the following changes

- Add pkg/common/events/recorder.go, it returns a global event recorder in singleton
- Publish events in multiple places, including
   `context.go` -> when nodes are accepted or deleted from the scheduler
   `task.go` -> when task is submitted/allocated/rejected/bound/bindFailed/completed
   `predicator.go` -> when a task is unable to be allocated due to unsatisfactory of predicates
- Add TestMode in configs, in order to avoid initiating event recorder in tests (it will panic because this requires a workable kube-client)
- Minor improvement to schedulerconf.go, change interval type from `int` to `time.Duration`