### PR TITLE
Add admission controller to mutate schedulerName on-the-fly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ admission:
 adm_image: admission
 	@echo "building admission controller docker images"
 	@cp ${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} ./deployments/image/admission
-	docker build ./deployments/image/admission -t yunikorn/scheduler-admission-controller:${VERSION} \
+	docker build ./deployments/image/admission -t yunikorn/scheduler-admission-controller:${VERSION}
 
 .PHONY: run
 run: build

--- a/deployments/admission-controllers/schedulername-mutation/README.md
+++ b/deployments/admission-controllers/schedulername-mutation/README.md
@@ -1,0 +1,66 @@
+# Admission Controller to inject SchedulerName on-the-fly
+
+This directory contains resources to create an admission controller web-hook which can inject
+`schedulerName` to pod's spec before admitting it. This can be used to deploy on an existing
+Kubernetes cluster and route all pods to YuniKorn, which can be treated as an alternative way
+to replace default scheduler.
+
+## Steps
+
+### Launch the admission controller
+
+Create the admission controller web-hook, run following command
+
+```
+./admission_util.sh create
+
+```
+this command does following tasks
+
+- Create private key and certificate
+- Sign and approve certificate with K8s `CertificateSigningRequest`
+- Create a K8s `secret` which stores the private key and signed certificate
+- Apply the secret to admission controller web-hook's deployment, insert the `caBundle`
+- Create the admission controller web-hook and launch it on K8s
+
+### Test the admission controller
+
+Launch a pod with following spec, note this spec did not specify `schedulerName`,
+without the admission controller, it should be scheduled by default scheduler without any issue.
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: sleep
+    applicationId: "application-sleep-0001"
+    queue: "root.sandbox"
+  name: task0
+spec:
+  containers:
+    - name: sleep-30s
+      image: "alpine:latest"
+      command: ["sleep", "30"]
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "500M"
+```
+
+However, after the admission controller is started, this pod will keep at pending state (if yunikorn is not running).
+Review the spec,
+
+```
+kubectl get pod task0 -o yaml 
+```
+
+you'll see the `schedulerName` has been injected with value `yunikorn`.
+
+### Cleanup
+
+Use following command to cleanup all resources
+```
+./admission_util.sh delete
+
+```

--- a/deployments/admission-controllers/schedulername-mutation/README.md
+++ b/deployments/admission-controllers/schedulername-mutation/README.md
@@ -11,9 +11,8 @@ to replace default scheduler.
 
 Create the admission controller web-hook, run following command
 
-```
+```shell script
 ./admission_util.sh create
-
 ```
 this command does following tasks
 
@@ -28,7 +27,7 @@ this command does following tasks
 Launch a pod with following spec, note this spec did not specify `schedulerName`,
 without the admission controller, it should be scheduled by default scheduler without any issue.
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -51,16 +50,16 @@ spec:
 However, after the admission controller is started, this pod will keep at pending state (if yunikorn is not running).
 Review the spec,
 
-```
+```shell script
 kubectl get pod task0 -o yaml 
 ```
 
 you'll see the `schedulerName` has been injected with value `yunikorn`.
 
-### Cleanup
+### Stop and delete the admission controller
 
 Use following command to cleanup all resources
-```
-./admission_util.sh delete
 
+```shell script
+./admission_util.sh delete
 ```

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -15,14 +15,22 @@
 # limitations under the License.
 
 basedir="$(dirname "$0")"
-SERVICE=`cat configs.properties | grep service | cut -d "=" -f 2`
-SECRET=`cat configs.properties | grep secret | cut -d "=" -f 2`
-NAMESPACE=`cat configs.properties | grep namespace | cut -d "=" -f 2`
+CONF_FILE="configs.properties"
+
+if [ ! -f ${CONF_FILE} ]; then
+  echo "${CONF_FILE} is missing in current directory!"
+  exit 1
+fi
+
+SERVICE=`cat ${CONF_FILE} | grep service | cut -d "=" -f 2`
+SECRET=`cat ${CONF_FILE} | grep secret | cut -d "=" -f 2`
+NAMESPACE=`cat ${CONF_FILE} | grep namespace | cut -d "=" -f 2`
 
 delete_resources() {
   kubectl delete -f server.yaml
   kubectl delete -n ${NAMESPACE} secret ${SECRET}
   kubectl delete -n ${NAMESPACE} certificatesigningrequest.certificates.k8s.io ${SERVICE}.${NAMESPACE}
+  kubectl delete namespace ${NAMESPACE}
   rm -rf server.yaml
   return 0
 }
@@ -42,9 +50,7 @@ create_resources() {
           --from-file=cert.pem=${KEY_DIR}/server-cert.pem \
           --namespace=${NAMESPACE}
 
-  # Read the PEM-encoded CA certificate, base64 encode it, and replace the `${CA_PEM_B64}` placeholder in the YAML
-  # template with it. Then, create the Kubernetes resources.
-  # ca_pem_b64="$(openssl base64 -A <"${KEY_DIR}/server.csr")"
+  # Replace the certificate in the template with a valid CA parsed from kube-config
   ca_pem_b64=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
   sed -e 's@${CA_PEM_B64}@'"$ca_pem_b64"'@g' <"${basedir}/server.yaml.template" > server.yaml
   kubectl create -f server.yaml

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -30,7 +30,6 @@ delete_resources() {
   kubectl delete -f server.yaml
   kubectl delete -n ${NAMESPACE} secret ${SECRET}
   kubectl delete -n ${NAMESPACE} certificatesigningrequest.certificates.k8s.io ${SERVICE}.${NAMESPACE}
-  kubectl delete namespace ${NAMESPACE}
   rm -rf server.yaml
   return 0
 }

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -40,8 +40,7 @@ create_resources() {
   kubectl create secret generic ${SECRET} \
           --from-file=key.pem=${KEY_DIR}/server-key.pem \
           --from-file=cert.pem=${KEY_DIR}/server-cert.pem \
-          --dry-run -o yaml |
-      kubectl -n ${NAMESPACE} apply -f -
+          --namespace=${NAMESPACE}
 
   # Read the PEM-encoded CA certificate, base64 encode it, and replace the `${CA_PEM_B64}` placeholder in the YAML
   # template with it. Then, create the Kubernetes resources.

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright 2019 Cloudera, Inc.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+basedir="$(dirname "$0")"
+SERVICE=`cat configs.properties | grep service | cut -d "=" -f 2`
+SECRET=`cat configs.properties | grep secret | cut -d "=" -f 2`
+NAMESPACE=`cat configs.properties | grep namespace | cut -d "=" -f 2`
+
+delete_resources() {
+  kubectl delete -f server.yaml
+  kubectl delete -n ${NAMESPACE} secret ${SECRET}
+  kubectl delete -n ${NAMESPACE} certificatesigningrequest.certificates.k8s.io ${SERVICE}.${NAMESPACE}
+  rm -rf server.yaml
+  return 0
+}
+
+create_resources() {
+  KEY_DIR=$1
+  # Generate keys into a temporary directory.
+  ${basedir}/generate-signed-ca.sh "${KEY_DIR}"
+
+  # Create the yunikorn namespace.
+  echo "Creating namespace ${NAMESPACE}"
+  kubectl create namespace ${NAMESPACE} &> /dev/null
+
+  # Create the TLS secret for the generated keys.
+  kubectl create secret generic ${SECRET} \
+          --from-file=key.pem=${KEY_DIR}/server-key.pem \
+          --from-file=cert.pem=${KEY_DIR}/server-cert.pem \
+          --dry-run -o yaml |
+      kubectl -n ${NAMESPACE} apply -f -
+
+  # Read the PEM-encoded CA certificate, base64 encode it, and replace the `${CA_PEM_B64}` placeholder in the YAML
+  # template with it. Then, create the Kubernetes resources.
+  # ca_pem_b64="$(openssl base64 -A <"${KEY_DIR}/server.csr")"
+  ca_pem_b64=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
+  sed -e 's@${CA_PEM_B64}@'"$ca_pem_b64"'@g' <"${basedir}/server.yaml.template" > server.yaml
+  kubectl create -f server.yaml
+
+  echo "The webhook server has been deployed and configured!"
+  return 0
+}
+
+usage() {
+  echo "usage: ${0} [OPTION]"
+  echo "  create"
+  echo "      Create admission controller and other related resources"
+  echo "  delete "
+  echo "      Delete all resources previously created"
+}
+
+if [ $# -eq 1 ] && [ $1 == "delete" ]; then
+  delete_resources
+  exit $?
+elif [ $# -eq 1 ] && [ $1 == "create" ]; then
+  KEY_DIR="$(mktemp -d)"
+  create_resources ${KEY_DIR}
+  rm -rf "$keydir"
+  exit $?
+else
+  usage
+  exit 1
+fi

--- a/deployments/admission-controllers/schedulername-mutation/configs.properties
+++ b/deployments/admission-controllers/schedulername-mutation/configs.properties
@@ -1,0 +1,3 @@
+service=yunikorn-admission-controller-service
+secret=webhook-server-tls
+namespace=yunikorn

--- a/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
+++ b/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
@@ -1,0 +1,97 @@
+# Copyright 2019 Cloudera, Inc.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${1?'missing output directory'}
+
+tmpdir="$1"
+service=`cat configs.properties | grep service | cut -d "=" -f 2`
+secret=`cat configs.properties | grep secret | cut -d "=" -f 2`
+namespace=`cat configs.properties | grep namespace | cut -d "=" -f 2`
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# send to K8s
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
+++ b/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
@@ -16,7 +16,6 @@
 
 tmpdir="$1"
 service=`cat configs.properties | grep service | cut -d "=" -f 2`
-secret=`cat configs.properties | grep secret | cut -d "=" -f 2`
 namespace=`cat configs.properties | grep namespace | cut -d "=" -f 2`
 
 if [ ! -x "$(command -v openssl)" ]; then
@@ -88,10 +87,3 @@ if [[ ${serverCert} == '' ]]; then
     exit 1
 fi
 echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
-
-# create the secret with CA cert and server cert/key
-kubectl create secret generic ${secret} \
-        --from-file=key.pem=${tmpdir}/server-key.pem \
-        --from-file=cert.pem=${tmpdir}/server-cert.pem \
-        --dry-run -o yaml |
-    kubectl -n ${namespace} apply -f -

--- a/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
+++ b/deployments/admission-controllers/schedulername-mutation/generate-signed-ca.sh
@@ -14,9 +14,16 @@
 
 : ${1?'missing output directory'}
 
+CONF_FILE="configs.properties"
+
+if [ ! -f ${CONF_FILE} ]; then
+  echo "${CONF_FILE} is missing in current directory!"
+  exit 1
+fi
+
 tmpdir="$1"
-service=`cat configs.properties | grep service | cut -d "=" -f 2`
-namespace=`cat configs.properties | grep namespace | cut -d "=" -f 2`
+service=`cat ${CONF_FILE} | grep service | cut -d "=" -f 2`
+namespace=`cat ${CONF_FILE} | grep namespace | cut -d "=" -f 2`
 
 if [ ! -x "$(command -v openssl)" ]; then
     echo "openssl not found"
@@ -65,11 +72,12 @@ spec:
 EOF
 
 # verify CSR has been created
-while true; do
+for x in $(seq 10); do
     kubectl get csr ${csrName}
     if [ "$?" -eq 0 ]; then
         break
     fi
+    sleep 1
 done
 
 # approve and fetch the signed certificate

--- a/deployments/admission-controllers/schedulername-mutation/server.yaml.template
+++ b/deployments/admission-controllers/schedulername-mutation/server.yaml.template
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yunikorn-admission-controller
+  namespace: yunikorn
+  labels:
+    app: yunikorn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: yunikorn
+  template:
+    metadata:
+      labels:
+        app: yunikorn
+    spec:
+      containers:
+        - name: yunikorn-admission-controller-webhook
+          image: yunikorn/scheduler-admission-controller:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8443
+            name: webhook-api
+          volumeMounts:
+          - name: webhook-tls-certs
+            mountPath: /run/secrets/tls
+            readOnly: true
+      volumes:
+      - name: webhook-tls-certs
+        secret:
+          secretName: webhook-server-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yunikorn-admission-controller-service
+  namespace: yunikorn
+  labels:
+    app: yunikorn
+spec:
+  ports:
+    - port: 443
+      targetPort: webhook-api
+  selector:
+    app: yunikorn
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: yunikorn-admission-controller-cfg
+  labels:
+    app: yunikorn
+webhooks:
+  - name: admission-webhook.yunikorn.svc
+    clientConfig:
+      service:
+        name: yunikorn-admission-controller-service
+        namespace: yunikorn
+        path: "/mutate"
+      caBundle: ${CA_PEM_B64}
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Ignore

--- a/deployments/image/admission/Dockerfile
+++ b/deployments/image/admission/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:latest
+
+ADD scheduler-admission-controller /scheduler-admission-controller
+ENTRYPOINT ["./scheduler-admission-controller"]

--- a/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
@@ -125,7 +125,6 @@ func (c *admissionController) serve(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 	} else {
-		fmt.Println(r.URL.Path)
 		if r.URL.Path == "/mutate" {
 			admissionResponse = c.mutate(&ar)
 		}

--- a/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 Cloudera, Inc.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cloudera/yunikorn-core/pkg/log"
+	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"net/http"
+)
+
+var  (
+	runtimeScheme = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(runtimeScheme)
+	deserializer  = codecs.UniversalDeserializer()
+)
+
+type admissionController struct {
+
+}
+
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func (c *admissionController) mutate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	log.Logger.Info("AdmissionReview",
+		zap.Any("Kind", req.Kind),
+		zap.String("Namespace", req.Namespace),
+		zap.String("UID", string(req.UID)),
+		zap.String("Operation", string(req.Operation)),
+		zap.Any("UserInfo", req.UserInfo))
+
+	var patch []patchOperation
+
+	switch req.Kind.Kind {
+	case "Pod":
+		var pod v1.Pod
+		if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+			return &v1beta1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: err.Error(),
+				},
+			}
+		}
+
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  "/spec/schedulerName",
+			Value: conf.GetSchedulerConf().SchedulerName,
+		})
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return &v1beta1.AdmissionResponse{
+		Allowed: true,
+		Patch:   patchBytes,
+		PatchType: func() *v1beta1.PatchType {
+			pt := v1beta1.PatchTypeJSONPatch
+			return &pt
+		}(),
+	}
+}
+
+func (c *admissionController) serve(w http.ResponseWriter, r *http.Request) {
+	log.Logger.Debug("request", zap.Any("httpRequest", r))
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		http.Error(w, "empty body", http.StatusBadRequest)
+		return
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		http.Error(w, "invalid Content-Type, expect `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var admissionResponse *v1beta1.AdmissionResponse
+	ar := v1beta1.AdmissionReview{}
+	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+		log.Logger.Error("Can't decode the body", zap.Error(err))
+		admissionResponse = &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	} else {
+		fmt.Println(r.URL.Path)
+		if r.URL.Path == "/mutate" {
+			admissionResponse = c.mutate(&ar)
+		}
+	}
+
+	admissionReview := v1beta1.AdmissionReview{}
+	if admissionResponse != nil {
+		admissionReview.Response = admissionResponse
+		if ar.Request != nil {
+			admissionReview.Response.UID = ar.Request.UID
+		}
+	}
+
+	resp, err := json.Marshal(admissionReview)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)
+	}
+
+	log.Logger.Info("writing response...")
+	if _, err := w.Write(resp); err != nil {
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/pkg/plugin/admissioncontrollers/webhook/webhook.go
+++ b/pkg/plugin/admissioncontrollers/webhook/webhook.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/cloudera/yunikorn-core/pkg/log"
-	"github.com/golang/glog"
 	"go.uber.org/zap"
 	"net/http"
 	"os"
@@ -42,7 +41,7 @@ func main() {
 	keyPath := filepath.Join(tlsDir, tlsKeyFile)
 	pair, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
-		glog.Fatal("Failed to load key pair: %v", err)
+		log.Logger.Fatal("Failed to load key pair", zap.Error(err))
 	}
 
 	webHook := admissionController{}

--- a/pkg/plugin/admissioncontrollers/webhook/webhook.go
+++ b/pkg/plugin/admissioncontrollers/webhook/webhook.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 Cloudera, Inc.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/cloudera/yunikorn-core/pkg/log"
+	"github.com/golang/glog"
+	"go.uber.org/zap"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	HttpPort    = 8443
+	tlsDir      = `/run/secrets/tls`
+	tlsCertFile = `cert.pem`
+	tlsKeyFile  = `key.pem`
+)
+
+func main() {
+	certPath := filepath.Join(tlsDir, tlsCertFile)
+	keyPath := filepath.Join(tlsDir, tlsKeyFile)
+	pair, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		glog.Fatal("Failed to load key pair: %v", err)
+	}
+
+	webHook := admissionController{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mutate", webHook.serve)
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%v", HttpPort),
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{pair}},
+		Handler: mux,
+	}
+
+	go func() {
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			log.Logger.Fatal("failed to start admission controller", zap.Error(err))
+		}
+	}()
+
+	log.Logger.Info("the admission controller started",
+		zap.Int("port", HttpPort),
+		zap.String("listeningOn", "/mutate"))
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	<-signalChan
+
+	log.Logger.Info("shutting down the admission controller...")
+	err = server.Shutdown(context.Background()); if err != nil {
+		log.Logger.Warn("failed to stop the admission controller",
+			zap.Error(err))
+	}
+}


### PR DESCRIPTION
This PR adds a `mutating` admission controller, it watches all pod creation operations, and automatically add `schedulerName=yunikorn` to the pod spec before admitting it to the validation phase. 