### PR TITLE
Handle "no transistion" error from state machine as a success and noop

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -118,13 +118,14 @@ func (app *Application) handle(ev events.ApplicationEvent) error {
 		zap.String("appId", app.applicationId),
 		zap.String("preState", app.sm.Current()),
 		zap.String("pendingEvent", string(ev.GetEvent())))
-	if err := app.sm.Event(string(ev.GetEvent()), ev.GetArgs()...); err != nil {
+	err := app.sm.Event(string(ev.GetEvent()), ev.GetArgs()...)
+	// handle the same state transition not nil error (limit of fsm).
+	if err != nil && err.Error() != "no transition" {
 		return err
 	}
 	log.Logger.Debug("application state transition",
 		zap.String("appId", app.applicationId),
-		zap.String("postState", app.sm.Current()),
-		zap.String("handledEvent", string(ev.GetEvent())))
+		zap.String("postState", app.sm.Current()))
 	return nil
 }
 

--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -124,12 +124,13 @@ func (n *SchedulerNode) handle(ev events.SchedulerNodeEvent) error {
 		zap.String("nodeId", ev.GetNodeId()),
 		zap.String("preState", n.fsm.Current()),
 		zap.String("pendingEvent", string(ev.GetEvent())))
-	if err := n.fsm.Event(string(ev.GetEvent()), ev.GetArgs()...); err != nil {
+	err := n.fsm.Event(string(ev.GetEvent()), ev.GetArgs()...)
+	// handle the same state transition not nil error (limit of fsm).
+	if err != nil && err.Error() != "no transition"{
 		return err
 	}
 	log.Logger.Debug("scheduler node state transition",
 		zap.String("nodeId", ev.GetNodeId()),
-		zap.String("postState", n.fsm.Current()),
-		zap.String("pendingEvent", string(ev.GetEvent())))
+		zap.String("postState", n.fsm.Current()))
 	return nil
 }

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -116,13 +116,14 @@ func (task *Task) handle(te events.TaskEvent) error {
 		zap.String("taskId", task.taskId),
 		zap.String("preState", task.sm.Current()),
 		zap.String("pendingEvent", string(te.GetEvent())))
-	if err := task.sm.Event(string(te.GetEvent()), te.GetArgs()...); err != nil {
+	err := task.sm.Event(string(te.GetEvent()), te.GetArgs()...)
+	// handle the same state transition not nil error (limit of fsm).
+	if err != nil && err.Error() != "no transition"{
 		return err
 	}
 	log.Logger.Debug("task state transition",
 		zap.String("taskId", task.taskId),
-		zap.String("postState", task.sm.Current()),
-		zap.String("handledEvent", string(te.GetEvent())))
+		zap.String("postState", task.sm.Current()))
 	return nil
 }
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -204,10 +204,12 @@ func (ss *KubernetesShim) handle(se events.SchedulerEvent) error {
 		zap.String("preState", ss.stateMachine.Current()),
 		zap.String("pending event", string(se.GetEvent())))
 	err := ss.stateMachine.Event(string(se.GetEvent()))
+	if err != nil && err.Error() == "no transition" {
+		return err
+	}
 	log.Logger.Info("shim-scheduler state transition",
-		zap.String("postState", ss.stateMachine.Current()),
-		zap.String("handled event", string(se.GetEvent())))
-	return err
+		zap.String("postState", ss.stateMachine.Current()))
+	return nil
 }
 
 // each schedule iteration, we scan all apps and triggers app state transition


### PR DESCRIPTION
This fixes issue #31 

Transparently handle a no transition event as a success