### PR TITLE
make sure containers are released when on task failures

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -651,6 +651,8 @@ func (ctx *Context) TaskEventHandler() func(obj interface{}){
 
 			if err := task.handle(event); err != nil {
 				log.Logger.Error("failed to handle task event",
+					zap.String("applicationId", task.applicationId),
+					zap.String("taskId", task.taskId),
 					zap.String("event", string(event.GetEvent())),
 					zap.Error(err))
 			}

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -232,10 +232,9 @@ func (ss *KubernetesShim) schedule() {
 				ev := cache.NewRunApplicationEvent(app.GetApplicationId(), pendingTask)
 				dispatcher.Dispatch(ev)
 			default:
-				log.Logger.Warn("application is in unexpected state, tasks cannot be scheduled under this state",
+				log.Logger.Debug("skipping scheduling application",
 					zap.String("appId", app.GetApplicationId()),
-					zap.String("appState", app.GetApplicationState()),
-					zap.String("desiredState", events.States().Application.Running))
+					zap.String("appState", app.GetApplicationState()))
 			}
 		}
 	}

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -19,7 +19,7 @@ package main
 import (
 	"fmt"
 	"github.com/cloudera/yunikorn-core/pkg/api"
-	utils "github.com/cloudera/yunikorn-core/pkg/common/configs"
+	coreconfigs "github.com/cloudera/yunikorn-core/pkg/common/configs"
 	"github.com/cloudera/yunikorn-core/pkg/entrypoint"
 	"github.com/cloudera/yunikorn-core/pkg/log"
 	"github.com/cloudera/yunikorn-k8shim/pkg/cache"
@@ -27,7 +27,7 @@ import (
 	"github.com/cloudera/yunikorn-k8shim/pkg/client"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common/test"
-	utils2 "github.com/cloudera/yunikorn-k8shim/pkg/common/utils"
+	"github.com/cloudera/yunikorn-k8shim/pkg/common/utils"
 	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
 	"github.com/cloudera/yunikorn-scheduler-interface/lib/go/si"
 	"go.uber.org/zap"
@@ -86,7 +86,7 @@ func (fc *MockScheduler) init(queues string) {
 
 	serviceContext := entrypoint.StartAllServices()
 	rmProxy := serviceContext.RMProxy
-	utils.MockSchedulerConfigByData([]byte(fc.conf))
+	coreconfigs.MockSchedulerConfigByData([]byte(fc.conf))
 
 	fakeClient := test.NewKubeClientMock()
 	fakeClient.MockBindFn(fc.bindFn)
@@ -210,7 +210,7 @@ func (fc *MockScheduler) waitAndVerifySchedulerAllocations(
 			return fmt.Errorf("partition %s is not found in the scheduler context", partitionName)
 		}
 
-		return utils2.WaitForCondition(func() bool {
+		return utils.WaitForCondition(func() bool {
 			for _, app := range partition.GetApplications() {
 				if app.ApplicationId == applicationId {
 					if len(app.GetAllAllocations()) == expectedNumOfAllocations {

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -21,13 +21,16 @@ import (
 	"github.com/cloudera/yunikorn-core/pkg/api"
 	utils "github.com/cloudera/yunikorn-core/pkg/common/configs"
 	"github.com/cloudera/yunikorn-core/pkg/entrypoint"
+	"github.com/cloudera/yunikorn-core/pkg/log"
 	"github.com/cloudera/yunikorn-k8shim/pkg/cache"
 	"github.com/cloudera/yunikorn-k8shim/pkg/callback"
 	"github.com/cloudera/yunikorn-k8shim/pkg/client"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common/test"
+	utils2 "github.com/cloudera/yunikorn-k8shim/pkg/common/utils"
 	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
 	"github.com/cloudera/yunikorn-scheduler-interface/lib/go/si"
+	"go.uber.org/zap"
 	"gotest.tools/assert"
 	"k8s.io/api/core/v1"
 	"testing"
@@ -42,14 +45,15 @@ const fakeClusterSchedulingInterval = 1
 // fake cluster is used for testing
 // it uses fake kube client to simulate API calls with k8s, all other code paths are real
 type MockScheduler struct {
-	context *cache.Context
-	scheduler *KubernetesShim
-	proxy  api.SchedulerApi
-	client client.KubeClient
-	conf string
-	bindFn func(pod *v1.Pod, hostId string) error
-	deleteFn func(pod *v1.Pod) error
-	stopChan chan struct{}
+	context     *cache.Context
+	scheduler   *KubernetesShim
+	proxy       api.SchedulerApi
+	client      client.KubeClient
+	coreContext *entrypoint.ServiceContext
+	conf        string
+	bindFn      func(pod *v1.Pod, hostId string) error
+	deleteFn    func(pod *v1.Pod) error
+	stopChan    chan struct{}
 }
 
 func (fc *MockScheduler) init(queues string) {
@@ -66,13 +70,18 @@ func (fc *MockScheduler) init(queues string) {
 	fc.conf = queues
 	fc.stopChan = make(chan struct{})
 	// default functions for bind and delete, this can be override if necessary
-	fc.deleteFn = func(pod *v1.Pod) error {
-		fmt.Printf("pod deleted")
-		return nil
+	if fc.deleteFn == nil {
+		fc.deleteFn = func(pod *v1.Pod) error {
+			fmt.Printf("pod deleted")
+			return nil
+		}
 	}
-	fc.bindFn = func(pod *v1.Pod, hostId string) error {
-		fmt.Printf("pod bound")
-		return nil
+
+	if fc.bindFn == nil {
+		fc.bindFn = func(pod *v1.Pod, hostId string) error {
+			fmt.Printf("pod bound")
+			return nil
+		}
 	}
 
 	serviceContext := entrypoint.StartAllServices()
@@ -93,6 +102,7 @@ func (fc *MockScheduler) init(queues string) {
 	fc.scheduler = ss
 	fc.proxy = schedulerApi
 	fc.client = fakeClient
+	fc.coreContext = serviceContext
 }
 
 func (fc *MockScheduler) start() {
@@ -124,9 +134,12 @@ func (fc *MockScheduler) waitForSchedulerState(t *testing.T, expectedState strin
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		if fc.scheduler.GetSchedulerState() == expectedState {
-			time.Sleep(1*time.Second)
 			break
 		}
+		log.Logger.Info("waiting for scheduler state",
+			zap.String("expected", expectedState),
+			zap.String("actual", fc.scheduler.GetSchedulerState()))
+		time.Sleep(time.Second)
 		if time.Now().After(deadline) {
 			t.Errorf("wait for scheduler to reach state %s failed, current state %s",
 				expectedState, fc.scheduler.GetSchedulerState() )
@@ -143,10 +156,12 @@ func (fc *MockScheduler) waitAndAssertApplicationState(t *testing.T, appId, expe
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		if appList[0].GetApplicationState() == expectedState {
-			time.Sleep(1*time.Second)
 			break
 		}
-
+		log.Logger.Info("waiting for app state",
+			zap.String("expected", expectedState),
+			zap.String("actual", appList[0].GetApplicationState()))
+		time.Sleep(time.Second)
 		if time.Now().After(deadline) {
 			t.Errorf("application %s doesn't reach expected state in given time, expecting: %s, actual: %s",
 				appId, expectedState, appList[0].GetApplicationState())
@@ -177,12 +192,34 @@ func (fc *MockScheduler) waitAndAssertTaskState(t *testing.T, appId, taskId, exp
 		if task.GetTaskState() == expectedState {
 			break
 		}
-
+		log.Logger.Info("waiting for task state",
+			zap.String("expected", expectedState),
+			zap.String("actual", task.GetTaskState()))
+		time.Sleep(time.Second)
 		if time.Now().After(deadline) {
 			t.Errorf("task %s doesn't reach expected state in given time, expecting: %s, actual: %s",
 				taskId, expectedState, task.GetTaskState())
 		}
 	}
+}
+
+func (fc *MockScheduler) waitAndVerifySchedulerAllocations(
+	queueName, partitionName, applicationId string, expectedNumOfAllocations int) error {
+		partition := fc.coreContext.Cache.GetPartition(partitionName)
+		if partition == nil {
+			return fmt.Errorf("partition %s is not found in the scheduler context", partitionName)
+		}
+
+		return utils2.WaitForCondition(func() bool {
+			for _, app := range partition.GetApplications() {
+				if app.ApplicationId == applicationId {
+					if len(app.GetAllAllocations()) != expectedNumOfAllocations {
+						return true
+					}
+				}
+			}
+			return false
+		}, time.Second, 5 * time.Second)
 }
 
 func (fc *MockScheduler) stop() {

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -40,7 +40,7 @@ import (
 const fakeClusterId = "test-cluster"
 const fakeClusterVersion = "0.1.0"
 const fakeClusterSchedulerName = "yunikorn-test"
-const fakeClusterSchedulingInterval = 1
+const fakeClusterSchedulingInterval = time.Second
 
 // fake cluster is used for testing
 // it uses fake kube client to simulate API calls with k8s, all other code paths are real
@@ -213,7 +213,7 @@ func (fc *MockScheduler) waitAndVerifySchedulerAllocations(
 		return utils2.WaitForCondition(func() bool {
 			for _, app := range partition.GetApplications() {
 				if app.ApplicationId == applicationId {
-					if len(app.GetAllAllocations()) != expectedNumOfAllocations {
+					if len(app.GetAllAllocations()) == expectedNumOfAllocations {
 						return true
 					}
 				}

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudera/yunikorn-k8shim/pkg/common/test"
 	"github.com/cloudera/yunikorn-scheduler-interface/lib/go/si"
 	"go.uber.org/zap"
+	"k8s.io/api/core/v1"
 	"testing"
 	"time"
 )
@@ -136,7 +137,7 @@ partitions:
 	app0001 = cluster.newApplication("app0001", "root.a")
 	cluster.addTask("task0001", taskResource, app0001)
 	cluster.addApplication(app0001)
-	cluster.waitAndAssertApplicationState(t, "app0001", events.States().Application.Accepted)
+	cluster.waitAndAssertApplicationState(t, "app0001", events.States().Application.Running)
 	cluster.waitAndAssertTaskState(t, "app0001", "task0001", events.States().Task.Bound)
 }
 
@@ -156,6 +157,74 @@ func TestSchedulerRegistrationFailed(t *testing.T){
 
 	if err := waitShimSchedulerState(shim, events.States().Scheduler.Stopped, 5 * time.Second); err !=nil {
 		t.Fatalf("%v", err)
+	}
+}
+
+func TestTaskFailures(t *testing.T) {
+	configData := `
+partitions:
+  -
+    name: default
+    queues:
+      -
+        name: root
+        queues:
+          -
+            name: a
+            resources:
+              guaranteed:
+                memory: 100
+                vcore: 10
+              max:
+                memory: 100
+                vcore: 10
+`
+	// init and register scheduler
+	cluster := MockScheduler{}
+	// mock pod bind failures
+	cluster.bindFn = func(pod *v1.Pod, hostId string) error {
+		if pod.Name == "task0001" {
+			return fmt.Errorf("mocked error when binding the pod")
+		}
+		return nil
+	}
+	cluster.init(configData)
+	cluster.start()
+	defer cluster.stop()
+
+	// ensure scheduler state
+	cluster.waitForSchedulerState(t, events.States().Scheduler.Running)
+
+	// register nodes
+	if err := cluster.addNode("test.host.01", 100, 10); err != nil {
+		t.Fatalf("add node failed %v", err)
+	}
+	if err := cluster.addNode("test.host.02", 100, 10); err != nil {
+		t.Fatalf("add node failed %v", err)
+	}
+
+	// create app and tasks
+	app0001 := cluster.newApplication("app0001", "root.a")
+	taskResource := common.NewResourceBuilder().
+		AddResource(common.Memory, 50).
+		AddResource(common.CPU, 5).
+		Build()
+	cluster.addTask("task0001", taskResource, app0001)
+	cluster.addTask("task0002", taskResource, app0001)
+
+	// add app to context
+	cluster.addApplication(app0001)
+
+	// wait for scheduling app and tasks
+	// verify app state
+	cluster.waitAndAssertApplicationState(t, "app0001", events.States().Application.Running)
+	cluster.waitAndAssertTaskState(t, "app0001", "task0001", events.States().Task.Failed)
+	cluster.waitAndAssertTaskState(t, "app0001", "task0002", events.States().Task.Bound)
+
+	// one task get bound, one ask failed, so we are expecting only 1 allocation in the scheduler
+	if err := cluster.waitAndVerifySchedulerAllocations("root.a",
+		"[test-cluster]default","app0001", 1); err != nil {
+		t.Fatalf("number of allocations is not expected %v", err)
 	}
 }
 

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -163,21 +163,22 @@ func TestSchedulerRegistrationFailed(t *testing.T){
 func TestTaskFailures(t *testing.T) {
 	configData := `
 partitions:
-  -
-    name: default
-    queues:
-      -
-        name: root
-        queues:
-          -
-            name: a
-            resources:
-              guaranteed:
-                memory: 100
-                vcore: 10
-              max:
-                memory: 100
-                vcore: 10
+ -
+   name: default
+   queues:
+     -
+       name: root
+       submitacl: "*"
+       queues:
+         -
+           name: a
+           resources:
+             guaranteed:
+               memory: 100
+               vcore: 10
+             max:
+               memory: 100
+               vcore: 10
 `
 	// init and register scheduler
 	cluster := MockScheduler{}
@@ -224,7 +225,7 @@ partitions:
 	// one task get bound, one ask failed, so we are expecting only 1 allocation in the scheduler
 	if err := cluster.waitAndVerifySchedulerAllocations("root.a",
 		"[test-cluster]default","app0001", 1); err != nil {
-		t.Fatalf("number of allocations is not expected %v", err)
+		t.Fatalf("number of allocations is not expected, error: %v", err)
 	}
 }
 


### PR DESCRIPTION
this fixes #29 

Here is what happens, when the shim failed to bind a pod to the specified node, we marked the task as failed. However, we are not asking scheduler-core to release these allocations, this is causing the issue seeing in #29. So this PR contains the following changes
- make sure containers are released on failures
- added test case to cover this scenario
- minor improvements to the logs
 