### PR TITLE
Dispatcher events could be lost when event channel is full

### DIFF
--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -32,6 +32,7 @@ const (
 	DefaultVolumeBindTimeout = 10 * time.Second
 	DefaultSchedulingInterval = time.Second
 	DefaultEventChannelCapacity = 1024 * 1024
+	DefaultDispatchTimeout = 300 * time.Second
 )
 
 var configuration *SchedulerConf
@@ -49,6 +50,7 @@ type SchedulerConf struct {
 	VolumeBindTimeout time.Duration `json:"volumeBindTimeout"`
 	TestMode          bool          `json:"testMode"`
 	EventChannelCapacity int        `json:"eventChannelCapacity"`
+	DispatchTimeout   time.Duration `json:"dispatchTimeout"`
 }
 
 func GetSchedulerConf() *SchedulerConf {
@@ -86,6 +88,8 @@ func init() {
 		"timeout in seconds when binding a volume")
 	eventChannelCapacity := flag.Int("eventChannelCapacity", DefaultEventChannelCapacity,
 		"event channel capacity of dispatcher")
+	dispatchTimeout := flag.Duration("dispatchTimeout", DefaultDispatchTimeout,
+		"timeout in seconds when dispatching an event")
 
 	// logging options
 	logLevel := flag.Int("logLevel", DefaultLoggingLevel,
@@ -109,5 +113,6 @@ func init() {
 		LogFile:           *logFile,
 		VolumeBindTimeout: *volumeBindTimeout,
 		EventChannelCapacity: *eventChannelCapacity,
+		DispatchTimeout:   *dispatchTimeout,
 	}
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -29,4 +29,5 @@ func TestDefaultValues(t *testing.T) {
 	assert.Equal(t, conf.LoggingLevel, DefaultLoggingLevel)
 	assert.Equal(t, conf.LogEncoding, DefaultLogEncoding)
 	assert.Equal(t, conf.EventChannelCapacity, DefaultEventChannelCapacity)
+	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 }

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -253,7 +253,7 @@ func TestExceedAsyncDispatchLimit(t *testing.T) {
 		AsyncDispatchLimit = 10000
 		// check error
 		if err := recover(); err != nil {
-			assert.Equal(t, err, ErrExcessAsyncDispatchLimit)
+			assert.Assert(t, strings.Contains(err.(error).Error(), "dispatcher exceeds async-dispatch limit"))
 		} else {
 			t.Error("Panic should be caught here")
 		}


### PR DESCRIPTION
Currently when event channel in dispatcher is full, events could be lost and an error like "failed to dispatch event, event channel is full or closed" can be found in the scheduler log.
To solve this problem, I suppose that new event should wait in Dispatcher#dispatch until it's enqueued into the channel, add a new test case for this scenario as well.