### PR TITLE
Deduplication of RunApplication events

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -180,6 +180,10 @@ func (app *Application) GetApplicationState() string {
 	return app.sm.Current()
 }
 
+func (app *Application) GetNewTasks() []*Task {
+	return app.getTasks(events.States().Task.New)
+}
+
 func (app *Application) GetPendingTasks() []*Task {
 	return app.getTasks(events.States().Task.Pending)
 }

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -56,13 +56,13 @@ func TestAddApplications(t *testing.T) {
 	assert.Equal(t, len(context.applications), 1)
 	assert.Assert(t, context.applications["app00001"] != nil)
 	assert.Equal(t, context.applications["app00001"].GetApplicationState(), events.States().Application.New)
-	assert.Equal(t, len(context.applications["app00001"].GetPendingTasks()), 0)
+	assert.Equal(t, len(context.applications["app00001"].GetNewTasks()), 0)
 
 	task01 := CreateTaskForTest("task00001", app01, nil, nil, nil)
 	task02 := CreateTaskForTest("task00002", app01, nil, nil, nil)
 	app01.AddTask(&task01)
 	app01.AddTask(&task02)
-	assert.Equal(t, len(context.applications["app00001"].GetPendingTasks()), 2)
+	assert.Equal(t, len(context.applications["app00001"].GetNewTasks()), 2)
 }
 
 func TestAddPod(t *testing.T) {
@@ -92,10 +92,10 @@ func TestAddPod(t *testing.T) {
 	app01 := context.getOrCreateApplication(&pod)
 	assert.Equal(t, len(context.applications), 1)
 	assert.Equal(t, app01.GetApplicationId(), "app00001")
-	assert.Equal(t, len(app01.GetPendingTasks()), 1)
-	assert.Equal(t, app01.GetPendingTasks()[0].GetTaskPod().Name, "pod00001")
-	assert.Equal(t, string(app01.GetPendingTasks()[0].GetTaskPod().UID), "UID-POD-00001")
-	assert.Equal(t, app01.GetPendingTasks()[0].GetTaskPod().Namespace, "default")
+	assert.Equal(t, len(app01.GetNewTasks()), 1)
+	assert.Equal(t, app01.GetNewTasks()[0].GetTaskPod().Name, "pod00001")
+	assert.Equal(t, string(app01.GetNewTasks()[0].GetTaskPod().UID), "UID-POD-00001")
+	assert.Equal(t, app01.GetNewTasks()[0].GetTaskPod().Namespace, "default")
 
 	// add same pod again
 	context.addPod(&pod)
@@ -124,9 +124,9 @@ func TestAddPod(t *testing.T) {
 	}
 	context.addPod(&pod1)
 	assert.Equal(t, len(context.applications), 1)
-	assert.Equal(t, len(app01.GetPendingTasks()), 2)
+	assert.Equal(t, len(app01.GetNewTasks()), 2)
 
-	for _, pt := range app01.GetPendingTasks() {
+	for _, pt := range app01.GetNewTasks() {
 		switch pt.GetTaskPod().Name {
 		case "pod00001" :
 			assert.Equal(t, string(pt.GetTaskPod().UID), "UID-POD-00001")
@@ -162,7 +162,7 @@ func TestAddPod(t *testing.T) {
 
 	context.addPod(&pod2)
 	assert.Equal(t, len(context.applications), 1)
-	assert.Equal(t, len(app01.GetPendingTasks()), 2)
+	assert.Equal(t, len(app01.GetNewTasks()), 2)
 
 	// add another pod from another app
 	pod3 := v1.Pod{
@@ -187,9 +187,9 @@ func TestAddPod(t *testing.T) {
 
 	context.addPod(&pod3)
 	assert.Equal(t, len(context.applications), 2)
-	assert.Equal(t, len(app01.GetPendingTasks()), 2)
+	assert.Equal(t, len(app01.GetNewTasks()), 2)
 	app02 := context.getOrCreateApplication(&pod3)
-	assert.Equal(t, len(app02.GetPendingTasks()), 1)
+	assert.Equal(t, len(app02.GetNewTasks()), 1)
 	assert.Equal(t, app02.GetApplicationId(), "app00002")
 }
 
@@ -224,16 +224,17 @@ func TestPodRejected(t *testing.T) {
 	app01 := context.getOrCreateApplication(&pod)
 	assert.Equal(t, len(context.applications), 1)
 	assert.Equal(t, app01.GetApplicationId(), "app00001")
-	assert.Equal(t, len(app01.GetPendingTasks()), 1)
-	assert.Equal(t, app01.GetPendingTasks()[0].GetTaskPod().Name, "pod00001")
-	assert.Equal(t, string(app01.GetPendingTasks()[0].GetTaskPod().UID), "UID-POD-00001")
-	assert.Equal(t, app01.GetPendingTasks()[0].GetTaskPod().Namespace, "default")
+	assert.Equal(t, len(app01.GetNewTasks()), 1)
+	assert.Equal(t, app01.GetNewTasks()[0].GetTaskPod().Name, "pod00001")
+	assert.Equal(t, string(app01.GetNewTasks()[0].GetTaskPod().UID), "UID-POD-00001")
+	assert.Equal(t, app01.GetNewTasks()[0].GetTaskPod().Namespace, "default")
 
 	// reject the task
 	task, _ := app01.GetTask("UID-POD-00001")
+	task.TransitionToPending()
 	err := task.handle(NewRejectTaskEvent("app00001", "UID-POD-00001", ""))
 	assert.Assert(t, err == nil)
-	assert.Equal(t, len(app01.GetPendingTasks()), 0)
+	assert.Equal(t, len(app01.GetNewTasks()), 0)
 
 	task01, err := app01.GetTask("UID-POD-00001")
 	assert.Assert(t, err == nil)

--- a/pkg/common/events/states.go
+++ b/pkg/common/events/states.go
@@ -61,6 +61,7 @@ type NodeStates struct {
 }
 
 type TaskStates struct {
+	New        string
 	Pending    string
 	Scheduling string
 	Allocated  string
@@ -88,6 +89,7 @@ func States() *AllStates {
 				Failed:     "Failed",
 			},
 			Task: &TaskStates{
+				New:        "New",
 				Pending:    "Pending",
 				Scheduling: "Scheduling",
 				Allocated:  "TaskAllocated",

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -227,27 +227,30 @@ func (ss *KubernetesShim) canHandle(se events.SchedulerEvent) bool {
 func (ss *KubernetesShim) schedule() {
 	apps := ss.context.SelectApplications(nil)
 	for _, app := range apps {
-		for _, pendingTask := range app.GetPendingTasks() {
-			var states = events.States().Application
-			log.Logger.Info("scheduling",
-				zap.String("app", app.GetApplicationId()),
-				zap.String("pendingTask", pendingTask.GetTaskPod().Name))
-			switch app.GetApplicationState() {
-			case states.New:
-				ev := cache.NewSubmitApplicationEvent(app.GetApplicationId())
-				dispatcher.Dispatch(ev)
-			case states.Accepted:
-				ev := cache.NewRunApplicationEvent(app.GetApplicationId(), pendingTask)
-				dispatcher.Dispatch(ev)
-			case states.Running:
-				ev := cache.NewRunApplicationEvent(app.GetApplicationId(), pendingTask)
-				dispatcher.Dispatch(ev)
-			default:
-				log.Logger.Debug("skipping scheduling application",
-					zap.String("appId", app.GetApplicationId()),
-					zap.String("appState", app.GetApplicationState()))
-			}
+		var states = events.States().Application
+		switch app.GetApplicationState() {
+		case states.New:
+			ev := cache.NewSubmitApplicationEvent(app.GetApplicationId())
+			dispatcher.Dispatch(ev)
+		case states.Accepted, states.Running:
+			ss.scheduleNewTasks(app)
+		default:
+			log.Logger.Debug("skipping scheduling application",
+				zap.String("appId", app.GetApplicationId()),
+				zap.String("appState", app.GetApplicationState()))
 		}
+	}
+}
+
+// schedule new tasks for specified app
+func (ss *KubernetesShim) scheduleNewTasks(app *cache.Application) {
+	for _, newTask := range app.GetNewTasks() {
+		log.Logger.Info("scheduling",
+			zap.String("app", app.GetApplicationId()),
+			zap.String("newTask", newTask.GetTaskPod().Name))
+		newTask.TransitionToPending()
+		ev := cache.NewRunApplicationEvent(app.GetApplicationId(), newTask)
+		dispatcher.Dispatch(ev)
 	}
 }
 


### PR DESCRIPTION
Currently RunApplication events can be generated repeatedly in KubernetesShim#schedule, especially when scheduling interval is very short or there are a huge number of pending tasks. Since tasks should wait at Pending state until RunApplication events are handled by its application, there's a gap in which KubernetesShim#schedule should be called for several times.
Updates in this PR:
(1) Add New state as the initial state for tasks, tasks will be transitioned to Pending state after generating RunApplication events.
(2) Refactor KubernetesShim#schedule to avoid iterating tasks and printing scheduling-task log at irrelevant app states like New etc.
(3) Add UT to test deduplication of RunApplication events

Similarly, SubmitApplication events may be generated repeatedly but not handled by this PR, it does less harm than RunApplication events since events of applications are much less than events of tasks.  We can handle it later if necessary.