### PR TITLE
embedded admission controller into helm chart deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ scheduler: init
 sched_image: scheduler
 	@echo "building scheduler docker image"
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
+	@mkdir -p deployments/image/configmap/admission-controller-init-scripts
+	@cp ./deployments/admission-controllers/schedulername-mutation/*  deployments/image/configmap/admission-controller-init-scripts/
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	@coreSHA=$$(go list -m "github.com/cloudera/yunikorn-core" | cut -d "-" -f4) ; \
 	siSHA=$$(go list -m "github.com/cloudera/yunikorn-scheduler-interface" | cut -d "-" -f5) ; \
@@ -110,6 +112,7 @@ sched_image: scheduler
 	--label "Version=${VERSION}"
 	@mv -f deployments/image/configmap/Dockerfile.bkp deployments/image/configmap/Dockerfile
 	@rm -f ./deployments/image/configmap/${BINARY}
+	@rm -rf ./deployments/image/configmap/admission-controller-init-scripts/
 
 # Build admission controller binary in a production ready version
 .PHONY: admission

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ scheduler: init
 sched_image: scheduler
 	@echo "building scheduler docker image"
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
-	@mkdir -p deployments/image/configmap/admission-controller-init-scripts
+	@mkdir -p ./deployments/image/configmap/admission-controller-init-scripts
 	@cp ./deployments/admission-controllers/schedulername-mutation/*  deployments/image/configmap/admission-controller-init-scripts/
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	@coreSHA=$$(go list -m "github.com/cloudera/yunikorn-core" | cut -d "-" -f4) ; \
@@ -110,7 +110,7 @@ sched_image: scheduler
 	--label "yunikorn-k8shim-revision=$${shimSHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}"
-	@mv -f deployments/image/configmap/Dockerfile.bkp deployments/image/configmap/Dockerfile
+	@mv -f ./deployments/image/configmap/Dockerfile.bkp ./deployments/image/configmap/Dockerfile
 	@rm -f ./deployments/image/configmap/${BINARY}
 	@rm -rf ./deployments/image/configmap/admission-controller-init-scripts/
 

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -34,6 +34,27 @@ delete_resources() {
   return 0
 }
 
+precheck() {
+  # depedency check
+  command -v kubectl &> /dev/null
+  if [ $? -ne 0 ]; then
+    echo "dependency check failed: kubectl is not installed"
+    exit 1
+  fi
+
+  command -v openssl &> /dev/null
+  if [ $? -ne 0 ]; then
+    echo "dependency check failed: jq is not installed"
+    exit 1
+  fi
+
+  command -v jq &> /dev/null
+  if [ $? -ne 0 ]; then
+    echo "dependency check failed: jq is not installed"
+    exit 1
+  fi
+}
+
 create_resources() {
   KEY_DIR=$1
   # Generate keys into a temporary directory.
@@ -70,6 +91,7 @@ if [ $# -eq 1 ] && [ $1 == "delete" ]; then
   delete_resources
   exit $?
 elif [ $# -eq 1 ] && [ $1 == "create" ]; then
+  precheck
   KEY_DIR="$(mktemp -d)"
   create_resources ${KEY_DIR}
   rm -rf "$keydir"

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -44,7 +44,7 @@ precheck() {
 
   command -v openssl &> /dev/null
   if [ $? -ne 0 ]; then
-    echo "dependency check failed: jq is not installed"
+    echo "dependency check failed: openssl is not installed"
     exit 1
   fi
 

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -1,4 +1,20 @@
 FROM alpine:latest
+
+# admission controller bundles
+RUN apk add curl
+RUN apk add jq
+RUN apk add --update openssl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.7/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl
+COPY admission-controller-init-scripts/admission_util.sh /
+COPY admission-controller-init-scripts/configs.properties /
+COPY admission-controller-init-scripts/generate-signed-ca.sh /
+COPY admission-controller-init-scripts/server.yaml.template /
+RUN chmod +x /admission_util.sh
+RUN chmod +x /generate-signed-ca.sh
+
+# scheduler binary
 ADD k8s_yunikorn_scheduler /k8s_yunikorn_scheduler
 ENTRYPOINT ["/k8s_yunikorn_scheduler"]
 CMD ["-logEncoding=console", "-logLevel=-1", "-clusterId=mycluster", "-clusterVersion=latest"]

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -32,6 +32,15 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/yunikorn/
+          {{ if .Values.embedAdmissionController }}
+          lifecycle:
+              postStart:
+                exec:
+                  command: ["/bin/sh", "/admission_util.sh", "create"]
+              preStop:
+                exec:
+                  command: ["/bin/sh", "/admission_util.sh", "delete"]
+          {{ end }}
         - name: yunikorn-scheduler-web
           image: "{{ .Values.web_image.repository }}:{{ .Values.web_image.tag }}"
           imagePullPolicy: {{ .Values.web_image.pullPolicy }}

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -20,6 +20,9 @@ service:
   port: 9080
   port_web: 9889
 
+# When this flag is true, the admission controller will be installed along with the scheduler.
+# When this flag is false, the admission controller will not be installed.
+# Once the admission controller is installed, all traffic will be routing to yunikorn.
 embedAdmissionController: true
 
 #

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -20,6 +20,8 @@ service:
   port: 9080
   port_web: 9889
 
+embedAdmissionController: true
+
 #
 # ------------------------------------------------------------------------
 # Please choose one configuration from following two for yunikorn

--- a/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"net/http"
+	"strings"
 )
 
 var  (
@@ -68,6 +69,13 @@ func (c *admissionController) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admis
 				Result: &metav1.Status{
 					Message: err.Error(),
 				},
+			}
+		}
+
+		if strings.HasPrefix(pod.Name, "yunikorn-scheduler") {
+			log.Logger.Info("ignore yunikorn scheduler pod")
+			return  &v1beta1.AdmissionResponse{
+				Allowed: true,
 			}
 		}
 


### PR DESCRIPTION
This patch is to simplify the deployment of the admission controller. Before this patch, we need to manually deploy the admission controller after scheduler is installed. After patch, all can be done by helm chart. And this patch does following:
- Pack the init scripts (generating certs, secrets etc) into the scheduler docker image
- In helm chart, added a property: `embedAdmissionController`, if true, the admission controller init hook will be triggered during the deployment of the scheduler, as a `postStart` hook.
- When we delete scheduler resources, it automatically deletes resources of the admission controller, including web-server, secrets, deployment, and service. This is done via `preStop` hook.
- If `embedAdmissionController` is false, no admission controller will be installed (the old behavior)
