### PR TITLE
Fix the caBundle issue in the admission controller in helm chart

### DIFF
--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -70,8 +70,7 @@ create_resources() {
           --from-file=cert.pem=${KEY_DIR}/server-cert.pem \
           --namespace=${NAMESPACE}
 
-  # Replace the certificate in the template with a valid CA parsed from kube-config
-  #ca_pem_b64=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
+  # Replace the certificate in the template with a valid CA parsed from security tokens
   ca_pem_b64=$(kubectl get secret -o jsonpath="{.items[?(@.type==\"kubernetes.io/service-account-token\")].data['ca\.crt']}" | cut -d " " -f 1)
   sed -e 's@${CA_PEM_B64}@'"$ca_pem_b64"'@g' <"${basedir}/server.yaml.template" > server.yaml
   kubectl create -f server.yaml

--- a/deployments/admission-controllers/schedulername-mutation/admission_util.sh
+++ b/deployments/admission-controllers/schedulername-mutation/admission_util.sh
@@ -71,7 +71,8 @@ create_resources() {
           --namespace=${NAMESPACE}
 
   # Replace the certificate in the template with a valid CA parsed from kube-config
-  ca_pem_b64=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
+  #ca_pem_b64=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
+  ca_pem_b64=$(kubectl get secret -o jsonpath="{.items[?(@.type==\"kubernetes.io/service-account-token\")].data['ca\.crt']}" | cut -d " " -f 1)
   sed -e 's@${CA_PEM_B64}@'"$ca_pem_b64"'@g' <"${basedir}/server.yaml.template" > server.yaml
   kubectl create -f server.yaml
 


### PR DESCRIPTION
During the test, I found when deploying the scheduler + admission controller using the helm chart. The webhook server log prints some "TLS handshake error". This was because of the `caBundle` value set for the webserver was missing. Kubectl is not able to retrieve cluster context using in cluster configuration (running inside of the pod). The fix is to change a way of retrieving the ca.

The fix works for both helm chart and local deployment. 