### PR TITLE
simplify the deployment and add some sample yaml

### DIFF
--- a/deployments/examples/admission-controller-tests/nginx-yk.yaml
+++ b/deployments/examples/admission-controller-tests/nginx-yk.yaml
@@ -1,7 +1,7 @@
-# this yaml sets the schedulerName to be "yunikorn", it also has
-# required info such as queue, applicationId defined. Even
-# admission controller is running, we don't expect these info
-# to be overwritten by any means.
+# This yaml sets the schedulerName to "yunikorn", it also has
+# the required info such as queue and applicationId defined. Even
+# if the admission controller is running, we don't expect this info
+# to be overwritten by the admission controller.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/deployments/examples/admission-controller-tests/nginx-yk.yaml
+++ b/deployments/examples/admission-controller-tests/nginx-yk.yaml
@@ -1,0 +1,29 @@
+# this yaml sets the schedulerName to be "yunikorn", it also has
+# required info such as queue, applicationId defined. Even
+# admission controller is running, we don't expect these info
+# to be overwritten by any means.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+        applicationId: "nginx_do_not_replace_my_id"
+        queue: root.default
+      name: nginx
+    spec:
+      schedulerName: yunikorn
+      containers:
+        - name: nginx
+          image: "nginx:1.11.1-alpine"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1024M"
+

--- a/deployments/examples/admission-controller-tests/nginx.yaml
+++ b/deployments/examples/admission-controller-tests/nginx.yaml
@@ -1,6 +1,6 @@
-# this yaml doesn't have any specify info for yunikorn
-# it depends on the admission-controller to mutate pod's spec
-# on the fly if it wants to be scheduled by yunikorn
+# This yaml doesn't have any specify info for yunikorn, it
+# depends on the admission-controller to mutate the pod's
+# spec on the fly if it wants to be scheduled by yunikorn.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/deployments/examples/admission-controller-tests/nginx.yaml
+++ b/deployments/examples/admission-controller-tests/nginx.yaml
@@ -1,0 +1,24 @@
+# this yaml doesn't have any specify info for yunikorn
+# it depends on the admission-controller to mutate pod's spec
+# on the fly if it wants to be scheduled by yunikorn
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+      name: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: "nginx:1.11.1-alpine"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1024M"

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -33,53 +33,53 @@ embedAdmissionController: true
 #
 
 # Use this configuration to automatically map K8s namespaces to yunikorn queues
-#configuration: |
-#  partitions:
-#    -
-#      name: default
-#      placementrules:
-#        - name: tag
-#          value: namespace
-#          create: true
-#      queues:
-#        - name: root
-#          submitacl: '*'
-
-# Use this configuration to configure absolute capacities for yunikorn queues
 configuration: |
   partitions:
     -
       name: default
+      placementrules:
+        - name: tag
+          value: namespace
+          create: true
       queues:
-        -
-          name: root
+        - name: root
           submitacl: '*'
-          queues:
-            -
-              name: advertisement
-              resources:
-                guaranteed:
-                  memory: 500000
-                  vcore: 50000
-                max:
-                  memory: 800000
-                  vcore: 80000
-            -
-              name: search
-              resources:
-                guaranteed:
-                  memory: 400000
-                  vcore: 40000
-                max:
-                  memory: 600000
-                  vcore: 60000
-            -
-              name: sandbox
-              resources:
-                guaranteed:
-                  memory: 100000
-                  vcore: 10000
-                max:
-                  memory: 100000
-                  vcore: 10000
+
+# Use this configuration to configure absolute capacities for yunikorn queues
+#configuration: |
+#  partitions:
+#    -
+#      name: default
+#      queues:
+#        -
+#          name: root
+#          submitacl: '*'
+#          queues:
+#            -
+#              name: advertisement
+#              resources:
+#                guaranteed:
+#                  memory: 500000
+#                  vcore: 50000
+#                max:
+#                  memory: 800000
+#                  vcore: 80000
+#            -
+#              name: search
+#              resources:
+#                guaranteed:
+#                  memory: 400000
+#                  vcore: 40000
+#                max:
+#                  memory: 600000
+#                  vcore: 60000
+#            -
+#              name: sandbox
+#              resources:
+#                guaranteed:
+#                  memory: 100000
+#                  vcore: 10000
+#                max:
+#                  memory: 100000
+#                  vcore: 10000
 


### PR DESCRIPTION
This PR contains 2 changes

1. use a simpler config for default deployment, that has placement rule enabled, no need to set queues explicitly.
2. add some sample yamls for admission-controller tests