### PR TITLE
Fix endless recovery problem

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -101,7 +101,6 @@ func NewApplication(appId, queueName, user string, tags map[string]string, sched
 		fsm.Callbacks{
 			//"enter_state":               app.handleTaskStateChange,
 			string(events.SubmitApplication):   app.handleSubmitApplicationEvent,
-			string(events.AcceptApplication):   app.handleAcceptApplicationEvent,
 			string(events.RecoverApplication):  app.handleRecoverApplicationEvent,
 			string(events.RejectApplication):   app.handleRejectApplicationEvent,
 			string(events.CompleteApplication): app.handleCompleteApplicationEvent,
@@ -277,10 +276,6 @@ func (app *Application) handleSubmitApplicationEvent(event *fsm.Event) {
 		log.Logger.Warn("failed to submit app", zap.Error(err))
 		dispatcher.Dispatch(NewFailApplicationEvent(app.applicationId))
 	}
-}
-
-func (app *Application) handleAcceptApplicationEvent(event *fsm.Event) {
-	dispatcher.Dispatch(NewRunApplicationEvent(app.applicationId))
 }
 
 func (app *Application) handleRecoverApplicationEvent(event *fsm.Event) {

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -86,7 +86,8 @@ func (ctx *Context) waitForAppRecovery(lister v1.PodLister, maxTimeout time.Dura
 				log.Logger.Info("appInfo",
 					zap.String("appId", app.applicationId),
 					zap.String("state", app.GetApplicationState()))
-				if app.GetApplicationState() == string(events.States().Application.Accepted) {
+				if app.GetApplicationState() != events.States().Application.New &&
+					app.GetApplicationState() != events.States().Application.Recovering {
 					delete(toRecoverApps, app.applicationId)
 				}
 			}

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -86,8 +86,7 @@ func (ctx *Context) waitForAppRecovery(lister v1.PodLister, maxTimeout time.Dura
 				log.Logger.Info("appInfo",
 					zap.String("appId", app.applicationId),
 					zap.String("state", app.GetApplicationState()))
-				if app.GetApplicationState() != events.States().Application.New &&
-					app.GetApplicationState() != events.States().Application.Recovering {
+				if app.GetApplicationState() == string(events.States().Application.Accepted) {
 					delete(toRecoverApps, app.applicationId)
 				}
 			}

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -23,14 +23,10 @@ import (
 	"github.com/cloudera/yunikorn-k8shim/pkg/common"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common/events"
 	"github.com/cloudera/yunikorn-k8shim/pkg/common/test"
-	"github.com/cloudera/yunikorn-k8shim/pkg/conf"
-	"github.com/cloudera/yunikorn-k8shim/pkg/dispatcher"
 	"github.com/cloudera/yunikorn-k8shim/pkg/log"
 	"github.com/cloudera/yunikorn-scheduler-interface/lib/go/si"
 	"go.uber.org/zap"
-	"gotest.tools/assert"
 	"k8s.io/api/core/v1"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -231,82 +227,6 @@ partitions:
 		"[test-cluster]default","app0001", 1); err != nil {
 		t.Fatalf("number of allocations is not expected, error: %v", err)
 	}
-}
-
-func TestApplicationSchedulingWithoutDuplicateEvents(t *testing.T) {
-	configData := `
-partitions:
-  - name: default
-    queues:
-      - name: root
-        submitacl: "*"
-        queues:
-          - name: a
-            resources:
-              guaranteed:
-                memory: 100
-                vcore: 10
-              max:
-                memory: 150
-                vcore: 20
-`
-	// init and register scheduler
-	cluster := MockScheduler{}
-	cluster.init(configData)
-	cluster.start()
-
-	// update scheduling interval and recover it at last
-	backupInterval := conf.GetSchedulerConf().Interval
-	conf.GetSchedulerConf().Interval = 0
-	defer func() {
-		conf.GetSchedulerConf().Interval = backupInterval
-		cluster.stop()
-	}()
-
-	// reset event handler for app events:
-	// pretend to be processed slowly so that scheduler may have the chance
-	// to generate duplicate events, and count RunApplication events for verification.
-	var numRunAppEvents int32 = 0
-	dispatcher.RegisterEventHandler(dispatcher.EventTypeApp, func(obj interface{}) {
-		if event, ok := obj.(events.ApplicationEvent); ok {
-			cluster.context.ApplicationEventHandler()(event)
-			if event.GetEvent() == events.RunApplication {
-				atomic.AddInt32(&numRunAppEvents, 1)
-			}
-			if atomic.LoadInt32(&numRunAppEvents) <= 2 {
-				time.Sleep(time.Millisecond)
-			}
-		}
-	})
-
-	// ensure scheduler state
-	cluster.waitForSchedulerState(t, events.States().Scheduler.Running)
-
-	// register nodes
-	if err := cluster.addNode("test.host.01", 100, 10); err != nil {
-		t.Fatalf("add node failed %v", err)
-	}
-
-	// create app and tasks
-	app0001 := cluster.newApplication("app0001", "root.a")
-	taskResource := common.NewResourceBuilder().
-		AddResource(common.Memory, 10).
-		AddResource(common.CPU, 1).
-		Build()
-	cluster.addTask("task0001", taskResource, app0001)
-	cluster.addTask("task0002", taskResource, app0001)
-
-	// add app to context
-	cluster.addApplication(app0001)
-
-	// wait for scheduling app and tasks
-	// verify app state
-	cluster.waitAndAssertApplicationState(t, "app0001", events.States().Application.Running)
-	cluster.waitAndAssertTaskState(t, "app0001", "task0001", events.States().Task.Bound)
-	cluster.waitAndAssertTaskState(t, "app0001", "task0002", events.States().Task.Bound)
-
-	// verify whether there are any duplicated RunApplication events
-	assert.Equal(t, int32(1), numRunAppEvents)
 }
 
 func waitShimSchedulerState(shim *KubernetesShim, expectedState string, timeout time.Duration) error {


### PR DESCRIPTION
After restarting scheduler with a running application which can be seen by the scheduler,  I found the recovery process is endless and always wait for the application whose state is Running. 
According to the code in Context#waitForAppRecovery, the condition to finish this recovery is that app state should be Accepted, but app state may also have a chance to be transitioned to Running and other states(like Completed, Killed, etc.) here.
Perhaps we can expect that recovery process of this app is finished when app state is not New and not Recovering?
@yangwwei @wilfred-s  please help to review this PR, thanks.