### PR TITLE
Support showing k8s logs in debug mode for better troubleshooting

### DIFF
--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -19,6 +19,8 @@ package conf
 import (
 	"flag"
 	"fmt"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"time"
 )
@@ -114,6 +116,14 @@ func init() {
 		"absolute log file path")
 
 	flag.Parse()
+
+	// if log level is debug, enable klog and set its log level verbosity to 4 (represents debug level),
+	// For details refer to the Logging Conventions of klog at
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+	if zapcore.Level(*logLevel).Enabled(zapcore.DebugLevel) {
+		klog.InitFlags(nil)
+		flag.Set("v", "4")
+	}
 
 	configuration = &SchedulerConf{
 		ClusterId:         *clusterId,


### PR DESCRIPTION
There are lots of invocations to k8s such as evaluating predicates for new allocations or assuming/binding volumes for pods, what we can see now are only final error messages.
This PR proposes to show internal logs in these invocations via enabling klog and set its log level verbosity to 4 (represents debug level) when log level of YK is debug.
For example, we can see more details in the failed invocation of volumeBinder#BindPodVolumes as follows,  also can find the cause of the error is empty node according to this message:
```
I1218 03:20:41.571713       1 scheduler_binder.go:344] BindPodVolumes for pod "blink/job-e896ad2d-ee9e-437b-8e6f-jobmanager-taskmanager-2", node ""
```
And we can see below messages after successfully bound pod volumes:
```
I1219 03:26:25.144935       1 scheduler_binder.go:344] BindPodVolumes for pod "blink/job-24f87693-f6e7-4e5c-9bfe-jobmanager-jobmanager-rc-rsgtc", node "i-8vb8rda7uhe0u7bfrchh"
I1219 03:26:25.144944       1 scheduler_binder.go:412] claim "blink/pv-job-24f87693-f6e7-4e5c-9bfe-jobmanager-jobmanager" bound to volume "local-pv-c77dff5a"
I1219 03:26:25.150104       1 scheduler_binder.go:417] updating PersistentVolume[local-pv-c77dff5a]: bound to "blink/pv-job-24f87693-f6e7-4e5c-9bfe-jobmanager-jobmanager"
```
I think it can help a lot for troubleshooting in some scenarios.